### PR TITLE
Fix DNS _ZONE

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ project: "daytona-test"
 cluster_name: "daytona-workspaces"
 
 # DNS zone that will be created in Cloud DNS.
-dns_zone: "daytona.example.com"
+dns_zone: "daytona.example.com."
 
 # The region to host the cluster in. This terraform will create Regional cluster
 region: "us-east1"

--- a/tf-1-gke/dns.tf
+++ b/tf-1-gke/dns.tf
@@ -1,5 +1,5 @@
 resource "google_dns_managed_zone" "zone" {
-  name        = replace(local.dns_zone, ".", "-")
+  name        = trim(replace(local.dns_zone, ".", "-"), "-")
   dns_name    = local.dns_zone
   description = "Test zone for GKE daytona workspaces"
 }


### PR DESCRIPTION
Based on DNS Zone specifications an absolute domain name as to end with an empty label (so just a `.`).
https://en.wikipedia.org/wiki/Fully_qualified_domain_name

# Testing
I used the changes to deploy it into my GCP project.