### PR TITLE
feat: update google provider

### DIFF
--- a/tf-1-gke/main.tf
+++ b/tf-1-gke/main.tf
@@ -5,11 +5,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.8"
+      version = "~> 5.8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.8"
+      version = "~> 5.8"
     }
 
   }


### PR DESCRIPTION
- update google provider since taint issue is resolver
- enable system metrics in google console UI
- enable longhorn support for cluster-autoscaler (needed for LH components running in workload pool)
- create longhorn custom priority class (give more priority when scheduling to LH pods)
- set bigger size nodes for both pools (adjusted to current load testing results)